### PR TITLE
Fixed a small mistake in the rebalance method

### DIFF
--- a/src/main/java/nl/jessenagel/highsjava/HiGHS.java
+++ b/src/main/java/nl/jessenagel/highsjava/HiGHS.java
@@ -300,7 +300,7 @@ public class HiGHS implements Modeler {
             //Write the constraints
             fileWriter.write("Subject To\n");
             for (Constraint constraint : constraints) {
-                this.rebalanceConstraint(constraint);
+                constraint = rebalanceConstraint(constraint);
                 HiGHSConstraint hiGHSConstraint = new HiGHSConstraint(constraint);
                 HiGHSNumExpr lhs_expr = new HiGHSNumExpr(hiGHSConstraint.lhs);
                 HiGHSNumExpr rhs_expr = new HiGHSNumExpr(hiGHSConstraint.rhs);
@@ -768,7 +768,7 @@ public class HiGHS implements Modeler {
      *
      * @param constraint The constraint to be rebalanced.
      */
-    public void rebalanceConstraint(Constraint constraint) {
+    public Constraint rebalanceConstraint(Constraint constraint) {
         HiGHSConstraint hiGHSConstraint = new HiGHSConstraint(constraint);
         HiGHSNumExpr lhs_expr = new HiGHSNumExpr(hiGHSConstraint.lhs);
         HiGHSNumExpr rhs_expr = new HiGHSNumExpr(hiGHSConstraint.rhs);
@@ -784,6 +784,7 @@ public class HiGHS implements Modeler {
         }
         hiGHSConstraint.rhs = constant( rhs_expr.constant - lhs_expr.constant);
         lhs_expr.constant = 0.0;
+        return hiGHSConstraint;
     }
 
 


### PR DESCRIPTION
This pull request refactors the `rebalanceConstraint` method in the `HiGHS.java` file to return a `Constraint` object instead of being void. This change ensures that the method's result can be directly used, improving code clarity and reducing side effects.

### Refactoring of `rebalanceConstraint`:

* Changed the return type of `rebalanceConstraint` from `void` to `Constraint` and updated its implementation to return the modified `HiGHSConstraint` object. [[1]](diffhunk://#diff-3226fc4d9da7dcf7a950cbc7525eba4e8041b775f9f0ba21673b070daf56303aL771-R771) [[2]](diffhunk://#diff-3226fc4d9da7dcf7a950cbc7525eba4e8041b775f9f0ba21673b070daf56303aR787)
* Updated the `exportModel` method to use the returned value of `rebalanceConstraint` directly by assigning it back to the `constraint` variable.