### PR TITLE
Fix: update process builder and add file cleanup in HiGHS.java

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -65,6 +65,7 @@ Currently, this API works by generating a `.lp` file and calling the HiGHS binar
 A more efficient approach would be to use the HiGHS C++ API directly from Java.
 The HiGHS4j project, which provides a Java interface to the HiGHS C++ API, does this but was not compatible with my requirements.
 Therefore, I decided to create this project.
+
 ## License
 This project is licensed under the MIT License. See the LICENSE file for details.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.jessenagel.highsjava</groupId>
     <artifactId>highs-java</artifactId>
-    <version>1.1.4-ALPHA</version>
+    <version>1.1.5-ALPHA</version>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/src/main/java/nl/jessenagel/highsjava/HiGHS.java
+++ b/src/main/java/nl/jessenagel/highsjava/HiGHS.java
@@ -762,11 +762,11 @@ public class HiGHS implements Modeler {
             //Delete created files after reading
             File file = new File("out-" + uniqueID + ".lp");
             if (!file.delete()) {
-                throw new RuntimeException("Failed to delete the file");
+                throw new RuntimeException("Failed to delete the file: " + file.getName());
             }
             file = new File("out-" + uniqueID + ".sol");
             if (!file.delete()){
-                throw new RuntimeException("Failed to delete the file");
+                throw new RuntimeException("Failed to delete the file: " + file.getName());
             }
 
         } catch (IOException | InterruptedException e) {

--- a/src/main/java/nl/jessenagel/highsjava/HiGHS.java
+++ b/src/main/java/nl/jessenagel/highsjava/HiGHS.java
@@ -750,7 +750,7 @@ public class HiGHS implements Modeler {
         // Write to file and call the solver
         exportModel("out-" + uniqueID + ".lp");
         try {
-            ProcessBuilder processBuilder = new ProcessBuilder("highs", "--model_file", "out-" + uniqueID + ".lp" , "--solution_file", "out-" + uniqueID + ".sol","--write_model_file", "out-" + uniqueID + ".lp");
+            ProcessBuilder processBuilder = new ProcessBuilder("highs", "--model_file", "out-" + uniqueID + ".lp" , "--solution_file", "out-" + uniqueID + ".sol");
             processBuilder.redirectOutput(new File("out.txt"));
             processBuilder.redirectError(new File("error.txt"));
             Process process = processBuilder.start();
@@ -759,6 +759,16 @@ public class HiGHS implements Modeler {
                 throw new RuntimeException("HiGHS solver failed with exit code: " + exitCode);
             }
             importSol("out-" + uniqueID + ".sol");
+            //Delete created files after reading
+            File file = new File("out-" + uniqueID + ".lp");
+            if (!file.delete()) {
+                throw new RuntimeException("Failed to delete the file");
+            }
+            file = new File("out-" + uniqueID + ".sol");
+            if (!file.delete()){
+                throw new RuntimeException("Failed to delete the file");
+            }
+
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This pull request includes updates to the `HiGHS.java` solver logic and a version bump in the `pom.xml` file. The changes focus on improving file management and updating the project version.

### Solver improvements:
* Removed the unused `--write_model_file` flag from the `ProcessBuilder` in the `solve()` method to simplify the solver invocation. (`src/main/java/nl/jessenagel/highsjava/HiGHS.java`)
* Added logic to delete temporary files (`.lp` and `.sol`) after processing, ensuring cleaner file management and preventing clutter. (`src/main/java/nl/jessenagel/highsjava/HiGHS.java`)

### Version update:
* Updated the project version from `1.1.4-ALPHA` to `1.1.5-ALPHA` in `pom.xml`, reflecting the new changes. (`pom.xml`)…version to 1.1.5-ALPHA